### PR TITLE
Add support for comparing more than two replays

### DIFF
--- a/scripts/compareReplays.js
+++ b/scripts/compareReplays.js
@@ -3,8 +3,8 @@ const util = require('util');
 const _ = require('lodash');
 const moment = require('moment');
 
-const replay1Path = String.raw`D:\Slippi\OnlineDesyncs\Post-Release\ZeroedInputs\Ashkon\AshkonPerspective.slp`;
-const replay2Path = String.raw`D:\Slippi\OnlineDesyncs\Post-Release\ZeroedInputs\Ashkon\OppPerspective.slp`;
+const replay1Path = String.raw`C:\Users\Owner\Documents\prog\slippi-replay-tester\Game_20220904T204903.slp`;
+const replay2Path = String.raw`C:\Users\Owner\Documents\prog\slippi-replay-tester\Game_20220904T204856.slp`;
 
 // Set to 0 to print all
 const framePrintMax = 50;
@@ -68,7 +68,8 @@ function findDifferences(f1, f2, type, playerIndex, isFollower) {
 		}
 
 		// difference[`${prefix}${type}-actionStateIdFixed-${playerIndex}`] = `${t1['actionStateId']} | ${t2['actionStateId']}`;
-		difference[`${prefix}${type}-${key}-${playerIndex}`] = `${printVal1} | ${printVal2}`;
+		// difference[`${prefix}${type}-${key}-${playerIndex}`] = `${printVal1} | ${printVal2}`;
+        difference[`${prefix}${type}-${key}-${playerIndex}`] = [printVal1, printVal2];
 	});
 
 	return difference;
@@ -123,7 +124,7 @@ while (game1Frames[iFrameIdx] && game2Frames[iFrameIdx]) {
 	if (!_.isEmpty(difference)) {
 		const duration = moment.duration((28800 - iFrameIdx) / 60, 'seconds');
 
-		console.log({
+		console.table({
 			frame: iFrameIdx,
 			sceneFrame: iFrameIdx + 123,
 			timer: moment.utc(duration.as('milliseconds')).format('m:ss.SSS'),

--- a/scripts/compareReplays.js
+++ b/scripts/compareReplays.js
@@ -110,8 +110,8 @@ while (gameFrames.every(e => e[iFrameIdx])) {
 		if (followerFrames.every(f => f !== null)) {
 			difference = {
 				...difference,
-				...findDifferences(followerFrames, "pre", player.playerIndex, false),
-				...findDifferences(followerFrames, "post", player.playerIndex, false),
+				...findDifferences(followerFrames, "pre", player.playerIndex, true),
+				...findDifferences(followerFrames, "post", player.playerIndex, true),
 			};
 		}
 	});


### PR DESCRIPTION
Updated `compareReplays.js` to allow comparison of arbitrarily many replays. Useful for inspecting Doubles desyncs.

Updated output to use `console.table()`

![image](https://user-images.githubusercontent.com/8659630/188693639-642dd40d-a1d9-42a1-83f9-e0f02e4f875d.png)
